### PR TITLE
Fix level logic to avoid property setter recursion

### DIFF
--- a/ViewModels/ArcheryViewModel.cs
+++ b/ViewModels/ArcheryViewModel.cs
@@ -178,19 +178,34 @@ namespace ArcherySimulator.ViewModels
 
         private void CheckForLevelChange()
         {
-            if (Level == 1 && (Experience < 0))
+            int oldExperience = experience;
+            int oldLevel = level;
+
+            if (level == 1 && experience < 0)
             {
-                Experience = 0;
+                experience = 0;
             }
-            if (Experience >= 100)
+
+            if (experience >= 100)
             {
-                Experience = Experience - 100;
-                Level += 1;
+                experience -= 100;
+                level += 1;
             }
-            else if (Experience < 0)
+            else if (experience < 0)
             {
-                Level -= 1;
-                Experience = 100 + Experience;
+                level -= 1;
+                experience = 100 + experience;
+            }
+
+            if (experience != oldExperience)
+            {
+                OnPropertyChanged(nameof(Experience));
+            }
+
+            if (level != oldLevel)
+            {
+                AddToLog("You are now level " + level);
+                OnPropertyChanged(nameof(Level));
             }
         }
 


### PR DESCRIPTION
## Summary
- update `CheckForLevelChange` to use backing fields and fire change notifications when they change
- call `CheckForLevelChange` once in `Experience` setter before raising `OnPropertyChanged`

## Testing
- `dotnet build ArcherySimulator.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f5b695c648324b65fe86f78714208