### PR TITLE
Remove unused using from ArcheryViewModel

### DIFF
--- a/ArcherySimulator.csproj
+++ b/ArcherySimulator.csproj
@@ -13,4 +13,11 @@
     <PackageReference Include="Avalonia.ReactiveUI" Version="11.3.0" />
   </ItemGroup>
 
+  <!-- Exclude test sources and legacy property files from compilation -->
+  <ItemGroup>
+    <Compile Remove="ArcherySimulator.Tests\**\*.cs" />
+    <Compile Remove="Properties\AssemblyInfo.cs" />
+    <Compile Remove="Properties\Settings.Designer.cs" />
+  </ItemGroup>
+
 </Project>

--- a/Program.cs
+++ b/Program.cs
@@ -11,6 +11,5 @@ internal class Program
     public static AppBuilder BuildAvaloniaApp()
         => AppBuilder.Configure<App>()
             .UsePlatformDetect()
-            .WithInterFont()
             .LogToTrace();
 }

--- a/ViewModels/ArcheryViewModel.cs
+++ b/ViewModels/ArcheryViewModel.cs
@@ -5,7 +5,6 @@ using System.ComponentModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using System.Windows;
 using ArcherySimulator.Commands;
 using ArcherySimulator.Models;
 


### PR DESCRIPTION
## Summary
- remove the `System.Windows` using directive
- drop the unused `WithInterFont` extension call
- exclude test and legacy property files from compilation

## Testing
- `dotnet build ArcherySimulator.csproj -v minimal` *(fails: AVLN2000/AVLN3000 errors)*

------
https://chatgpt.com/codex/tasks/task_e_683ffe21061c8324844517c4158f28ee