### PR TITLE
Add GUI unit tests

### DIFF
--- a/ArcherySimulator.Tests/ArcheryViewGuiTests.cs
+++ b/ArcherySimulator.Tests/ArcheryViewGuiTests.cs
@@ -1,0 +1,42 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using ArcherySimulator.Views;
+using ArcherySimulator.ViewModels;
+
+namespace ArcherySimulator.Tests;
+
+[TestClass]
+public class ArcheryViewGuiTests
+{
+    [TestMethod]
+    public async Task BreakButton_Disables_After_Command()
+    {
+        using var session = HeadlessUnitTestSession.StartNew(typeof(Program));
+        await session.Dispatch(() =>
+        {
+            var view = new ArcheryView();
+            var grid = (Grid)view.Content!;
+            var breakButton = grid.Children.OfType<Button>()
+                .First(c => (string?)c.Content == "Break");
+
+            Assert.IsTrue(breakButton.IsEnabled);
+            breakButton.Command!.Execute(null);
+            Assert.IsFalse(breakButton.IsEnabled);
+        });
+    }
+
+    [TestMethod]
+    public async Task View_Has_All_Action_Buttons()
+    {
+        using var session = HeadlessUnitTestSession.StartNew(typeof(Program));
+        await session.Dispatch(() =>
+        {
+            var view = new ArcheryView();
+            var grid = (Grid)view.Content!;
+            var buttons = grid.Children.OfType<Button>().Select(b => b.Content?.ToString()).ToList();
+            CollectionAssert.AreEquivalent(new[] { "Train", "Sleep", "Shoot", "Break" }, buttons);
+        });
+    }
+}

--- a/ArcherySimulator.Tests/ArcheryViewGuiTests.cs
+++ b/ArcherySimulator.Tests/ArcheryViewGuiTests.cs
@@ -1,9 +1,9 @@
 using System.Linq;
 using System.Threading.Tasks;
+using System.Threading;
 using Avalonia.Controls;
 using Avalonia.Headless;
 using ArcherySimulator.Views;
-using ArcherySimulator.ViewModels;
 
 namespace ArcherySimulator.Tests;
 
@@ -24,7 +24,7 @@ public class ArcheryViewGuiTests
             Assert.IsTrue(breakButton.IsEnabled);
             breakButton.Command!.Execute(null);
             Assert.IsFalse(breakButton.IsEnabled);
-        });
+        }, CancellationToken.None);
     }
 
     [TestMethod]
@@ -37,6 +37,6 @@ public class ArcheryViewGuiTests
             var grid = (Grid)view.Content!;
             var buttons = grid.Children.OfType<Button>().Select(b => b.Content?.ToString()).ToList();
             CollectionAssert.AreEquivalent(new[] { "Train", "Sleep", "Shoot", "Break" }, buttons);
-        });
+        }, CancellationToken.None);
     }
 }

--- a/ArcherySimulator.Tests/AvaloniaTestSetup.cs
+++ b/ArcherySimulator.Tests/AvaloniaTestSetup.cs
@@ -1,0 +1,5 @@
+using Avalonia.Headless;
+using ArcherySimulator;
+
+[assembly: AvaloniaTestApplication(typeof(Program))]
+

--- a/Program.cs
+++ b/Program.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace ArcherySimulator;
 
-internal class Program
+public class Program
 {
     public static void Main(string[] args) => BuildAvaloniaApp()
         .StartWithClassicDesktopLifetime(args);


### PR DESCRIPTION
## Summary
- introduce Avalonia headless test setup for GUI
- test that the `Break` button disables itself when clicked
- verify `ArcheryView` defines four action buttons

## Testing
- `dotnet test ArcherySimulator.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68403cc08a208324a1742b1b17975974